### PR TITLE
メモリアロケーター本体の実装

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,8 +2,11 @@
 target = "x86_64-unknown-uefi"
 rustflags = ["-Cforce-unwind-tables", "-Cforce-frame-pointers", "-Cno-redzone"]
 
+[lib]
+target = "x86_64-unknown-uefi"
+
 [unstable]
-build-std = ["core", "compiler_builtins", "panic_abort"]
+build-std = ["core", "compiler_builtins", "alloc", "panic_abort"]
 build-std-features = ["compiler-builtins-mem"]
 
 [target. 'cfg(target_os = "uefi")']

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 /mnt
 /bin
+/log/*
+!/log/.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,13 @@ run-uefi: build
 	mkdir -p mnt/EFI/BOOT
 	cp $(PATH_TO_EFI) mnt/EFI/BOOT/BOOTX64.EFI
 	set +e; \
-	qemu-system-x86_64 -m 4G -bios third_party/ovmf/RELEASEX64_OVMF.fd -drive format=raw,file=fat:rw:mnt -device isa-debug-exit,iobase=0xf4,iosize=0x01; \
+	qemu-system-x86_64 \
+		-m 4G \
+		-bios third_party/ovmf/RELEASEX64_OVMF.fd \
+		-drive format=raw,file=fat:rw:mnt \
+		-chardev stdio,id=char_com1,mux=on,logfile=log/com1.txt \
+		-serial chardev:char_com1 \
+		-device isa-debug-exit,iobase=0xf4,iosize=0x01; \
 	EXIT_CODE=$$?; \
 	set -e; \
 	if [ $$EXIT_CODE -eq 0 ]; then \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "nightly-2024-01-01"
-components = ["rustfmt", "rust-src"]
-targets = ["x86_64-unknown-linux-gnu"]
+components = [ "rustfmt" ]
+targets = [ "x86_64-unknown-uefi", "x86_64-unknown-none" ]
 profile = "default"

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1,0 +1,325 @@
+extern crate alloc;
+
+use crate::result::Result;
+use crate::uefi::EfiMemoryDescriptor;
+use crate::uefi::EfiMemoryType;
+use crate::uefi::MemoryMapHolder;
+use alloc::alloc::GlobalAlloc;
+use alloc::alloc::Layout;
+use alloc::boxed::Box;
+use core::borrow::BorrowMut;
+use core::cell::RefCell;
+use core::cmp::max;
+use core::fmt;
+use core::mem::size_of;
+use core::ops::DerefMut;
+use core::ptr::null_mut;
+
+pub fn round_up_to_nearest_pow2(v: usize) -> Result<usize> {
+    1usize
+        .checked_shl(usize::BITS - v.wrapping_sub(1).leading_zeros())
+        .ok_or("out of round up range")
+}
+
+#[test_case]
+fn round_up_to_nearest_pow2_test() {
+    assert_eq!(round_up_to_nearest_pow2(0), Err("out of round up range"));
+    assert_eq!(round_up_to_nearest_pow2(1), Ok(1));
+    assert_eq!(round_up_to_nearest_pow2(2), Ok(2));
+    assert_eq!(round_up_to_nearest_pow2(3), Ok(4));
+    assert_eq!(round_up_to_nearest_pow2(4), Ok(4));
+    assert_eq!(round_up_to_nearest_pow2(5), Ok(8));
+    assert_eq!(round_up_to_nearest_pow2(6), Ok(8));
+    assert_eq!(round_up_to_nearest_pow2(7), Ok(8));
+    assert_eq!(round_up_to_nearest_pow2(8), Ok(8));
+    assert_eq!(round_up_to_nearest_pow2(9), Ok(16));
+}
+
+struct Header {
+    next_header: Option<Box<Header>>,
+    size: usize,
+    is_allocated: bool,
+    _reserved: usize,
+}
+
+const HEADER_SIZE: usize = size_of::<Header>();
+
+#[allow(clippy::assertions_on_constants)]
+const _: () = assert!(HEADER_SIZE == 32);
+const _: () = assert!(HEADER_SIZE.count_ones() == 1);
+
+pub const LAYOUT_PAGE_4K: Layout = unsafe { Layout::from_size_align_unchecked(4096, 4096) };
+
+impl Header {
+    fn can_privide(&self, size: usize, align: usize) -> bool {
+        self.size >= size + HEADER_SIZE * 2 + align
+    }
+    fn is_allocated(&self) -> bool {
+        self.is_allocated
+    }
+    fn end_addr(&self) -> usize {
+        self as *const Header as usize + self.size
+    }
+    unsafe fn new_from_addr(addr: usize) -> Box<Header> {
+        let header = addr as *mut Header;
+        header.write(Header {
+            next_header: None,
+            size: 0,
+            is_allocated: false,
+            _reserved: 0,
+        });
+        Box::from_raw(addr as *mut Header)
+    }
+    unsafe fn from_allocated_region(addr: *mut u8) -> Box<Header> {
+        let header = addr.sub(HEADER_SIZE) as *mut Header;
+        Box::from_raw(header)
+    }
+    fn provide(&mut self, size: usize, align: usize) -> Option<*mut u8> {
+        let size = max(round_up_to_nearest_pow2(size).ok()?, HEADER_SIZE);
+        let align = max(align, HEADER_SIZE);
+        if self.is_allocated() || !self.can_privide(size, align) {
+            None
+        } else {
+            let mut size_used = 0;
+            let allocated_addr = (self.end_addr() - size) & !(align - 1);
+            let mut header_for_allocated =
+                unsafe { Self::new_from_addr(allocated_addr - HEADER_SIZE) };
+            header_for_allocated.is_allocated = true;
+            header_for_allocated.size = size + HEADER_SIZE;
+            size_used += header_for_allocated.size;
+            header_for_allocated.next_header = self.next_header.take();
+            if header_for_allocated.end_addr() != self.end_addr() {
+                let mut header_for_padding =
+                    unsafe { Self::new_from_addr(header_for_allocated.end_addr()) };
+                header_for_padding.is_allocated = false;
+                header_for_padding.size = self.end_addr() - header_for_allocated.end_addr();
+                size_used += header_for_padding.size;
+                header_for_padding.next_header = header_for_allocated.next_header.take();
+                header_for_allocated.next_header = Some(header_for_padding);
+            }
+
+            assert!(self.size >= size_used + HEADER_SIZE);
+            self.size -= size_used;
+            self.next_header = Some(header_for_allocated);
+            Some(allocated_addr as *mut u8)
+        }
+    }
+}
+
+impl Drop for Header {
+    fn drop(&mut self) {
+        panic!("header should not be dropped!")
+    }
+}
+
+impl fmt::Debug for Header {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Header @ {:#018X} {{ size: {:#018X}、is_allocated: {} }}",
+            self as *const Header as usize,
+            self.size,
+            self.is_allocated()
+        )
+    }
+}
+
+pub struct FirstFitAllocator {
+    first_header: RefCell<Option<Box<Header>>>,
+}
+
+#[global_allocator]
+pub static ALLOCATOR: FirstFitAllocator = FirstFitAllocator {
+    first_header: RefCell::new(None),
+};
+
+unsafe impl Sync for FirstFitAllocator {}
+
+unsafe impl GlobalAlloc for FirstFitAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        self.alloc_with_options(layout)
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        let mut region = Header::from_allocated_region(ptr);
+        region.is_allocated = false;
+        Box::leak(region);
+    }
+}
+
+impl FirstFitAllocator {
+    pub fn alloc_with_options(&self, layout: Layout) -> *mut u8 {
+        let mut header = self.first_header.borrow_mut();
+        let mut header = header.deref_mut();
+        loop {
+            match header {
+                Some(e) => match e.provide(layout.size(), layout.align()) {
+                    Some(p) => break p,
+                    None => {
+                        header = e.next_header.borrow_mut();
+                        continue;
+                    }
+                },
+                None => {
+                    break null_mut::<u8>();
+                }
+            }
+        }
+    }
+    pub fn init_with_mmap(&self, memory_map: &MemoryMapHolder) {
+        for e in memory_map.iter() {
+            if e.memory_type() != EfiMemoryType::CONVENTIONAL_MEMORY {
+                continue;
+            }
+            self.add_free_from_descriptor(e);
+        }
+    }
+    fn add_free_from_descriptor(&self, desc: &EfiMemoryDescriptor) {
+        let mut start_addr = desc.physical_start() as usize;
+        let mut size = desc.number_of_pages() as usize * 4096;
+
+        if start_addr == 0 {
+            start_addr += 4096;
+            size = size.saturating_sub(4096);
+        }
+        if size <= 4096 {
+            return;
+        }
+
+        let mut header = unsafe { Header::new_from_addr(start_addr) };
+        header.next_header = None;
+        header.is_allocated = false;
+        header.size = size;
+        let mut first_header = self.first_header.borrow_mut();
+        let prev_last = first_header.replace(header);
+        drop(first_header);
+        let mut header = self.first_header.borrow_mut();
+        header.as_mut().unwrap().next_header = prev_last;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use alloc::vec;
+
+    #[test_case]
+    fn malloc_iterate_free_and_alloc() {
+        use alloc::vec::Vec;
+        for i in 0..1000 {
+            let mut vec = Vec::new();
+            vec.resize(i, 10);
+        }
+    }
+
+    #[test_case]
+    fn malloc_align() {
+        let mut pointers = [null_mut::<u8>(); 100];
+        for align in [1, 2, 4, 8, 16, 32, 4096] {
+            for ptr in pointers.iter_mut() {
+                *ptr = ALLOCATOR.alloc_with_options(
+                    Layout::from_size_align(1234, align).expect("failed to create Layout"),
+                );
+                assert!(*ptr as usize != 0);
+                assert!((*ptr as usize) % align == 0);
+            }
+        }
+    }
+
+    #[test_case]
+    fn malloc_align_random_order() {
+        for align in [32, 4096, 8, 4, 16, 2, 1] {
+            let mut pointers = [null_mut::<u8>(); 100];
+            for ptr in pointers.iter_mut() {
+                *ptr = ALLOCATOR.alloc_with_options(Layout::from_size_align(1234, align).unwrap());
+                assert!(*ptr as usize != 0);
+                assert!((*ptr as usize) % align == 0);
+            }
+        }
+    }
+
+    #[test_case]
+    fn allocated_objects_have_no_overlap() {
+        let allocations = [
+            Layout::from_size_align(1, 1).unwrap(),
+            Layout::from_size_align(1, 2).unwrap(),
+            Layout::from_size_align(1, 4).unwrap(),
+            Layout::from_size_align(2, 2).unwrap(),
+            Layout::from_size_align(2, 4).unwrap(),
+            Layout::from_size_align(4, 4).unwrap(),
+            Layout::from_size_align(4, 8).unwrap(),
+            Layout::from_size_align(8, 8).unwrap(),
+            Layout::from_size_align(16, 16).unwrap(),
+            Layout::from_size_align(32, 32).unwrap(),
+            Layout::from_size_align(64, 1).unwrap(),
+            Layout::from_size_align(100, 4).unwrap(),
+            Layout::from_size_align(128, 128).unwrap(),
+            Layout::from_size_align(256, 256).unwrap(),
+            Layout::from_size_align(512, 512).unwrap(),
+            Layout::from_size_align(768, 256).unwrap(),
+            Layout::from_size_align(1024, 1024).unwrap(),
+            Layout::from_size_align(2048, 2048).unwrap(),
+            Layout::from_size_align(3000, 8).unwrap(),
+            Layout::from_size_align(4096, 4096).unwrap(),
+            Layout::from_size_align(5120, 128).unwrap(),
+            Layout::from_size_align(6000, 64).unwrap(),
+            Layout::from_size_align(8192, 16).unwrap(),
+            Layout::from_size_align(16384, 32).unwrap(),
+            Layout::from_size_align(123456, 16384).unwrap(),
+        ];
+        let mut pointers = vec![null_mut::<u8>(); allocations.len()];
+        for e in allocations.iter().zip(pointers.iter_mut()).enumerate() {
+            let (i, (layout, pointer)) = e;
+            *pointer = ALLOCATOR.alloc_with_options(*layout);
+            for k in 0..layout.size() {
+                unsafe { *pointer.add(k) = i as u8 }
+            }
+        }
+        for e in allocations.iter().zip(pointers.iter_mut()).enumerate() {
+            let (i, (layout, pointer)) = e;
+            for k in 0..layout.size() {
+                assert!(unsafe { *pointer.add(k) } == i as u8);
+            }
+        }
+        for e in allocations
+            .iter()
+            .zip(pointers.iter_mut())
+            .enumerate()
+            .step_by(2)
+        {
+            let (_, (layout, pointer)) = e;
+            unsafe {
+                ALLOCATOR.dealloc(*pointer, *layout);
+            }
+        }
+        for e in allocations
+            .iter()
+            .zip(pointers.iter_mut())
+            .enumerate()
+            .skip(1)
+            .step_by(2)
+        {
+            let (i, (layout, pointer)) = e;
+            for k in 0..layout.size() {
+                assert!(unsafe { *pointer.add(k) } == i as u8);
+            }
+        }
+        for e in allocations
+            .iter()
+            .zip(pointers.iter_mut())
+            .enumerate()
+            .step_by(2)
+        {
+            let (i, (layout, pointer)) = e;
+            *pointer = ALLOCATOR.alloc_with_options(*layout);
+            for k in 0..layout.size() {
+                unsafe { *pointer.add(k) = i as u8 }
+            }
+        }
+        for e in allocations.iter().zip(pointers.iter_mut()).enumerate() {
+            let (i, (layout, pointer)) = e;
+            for k in 0..layout.size() {
+                assert!(unsafe { *pointer.add(k) } == i as u8)
+            }
+        }
+    }
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,14 @@
+use crate::{
+    allocator::ALLOCATOR,
+    uefi::{exit_from_efi_boot_services, EfiHandle, EfiSystemTable, MemoryMapHolder},
+};
+
+pub fn init_basic_runtime(
+    image_handle: EfiHandle,
+    efi_system_table: &EfiSystemTable,
+) -> MemoryMapHolder {
+    let mut memory_map = MemoryMapHolder::new();
+    exit_from_efi_boot_services(image_handle, efi_system_table, &mut memory_map);
+    ALLOCATOR.init_with_mmap(&memory_map);
+    memory_map
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,12 @@
 #![test_runner(crate::test_runner::test_runner)]
 #![reexport_test_harness_main = "run_unit_tests"]
 #![no_main]
+pub mod allocator;
 pub mod graphics;
+pub mod init;
 pub mod qemu;
 pub mod result;
+pub mod serial;
 pub mod uefi;
 pub mod x86;
 
@@ -15,6 +18,7 @@ pub mod test_runner;
 
 #[cfg(test)]
 #[no_mangle]
-pub fn efi_main() {
+fn efi_main(image_handle: uefi::EfiHandle, efi_system_table: &uefi::EfiSystemTable) {
+    init::init_basic_runtime(image_handle, efi_system_table);
     run_unit_tests()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,37 +8,33 @@ use core::writeln;
 use wasabi::graphics::draw_test_pattern;
 use wasabi::graphics::fill_rect;
 use wasabi::graphics::Bitmap;
+use wasabi::init::init_basic_runtime;
 use wasabi::qemu::exit_qemu;
 use wasabi::qemu::QemuExitCode;
-use wasabi::uefi::exit_from_efi_boot_services;
+use wasabi::serial::SerialPort;
 use wasabi::uefi::init_vram;
 use wasabi::uefi::EfiHandle;
 use wasabi::uefi::EfiMemoryType;
 use wasabi::uefi::EfiSystemTable;
-use wasabi::uefi::MemoryMapHolder;
 use wasabi::uefi::VramTextWriter;
 use wasabi::x86::hlt;
 
 #[no_mangle]
 fn efi_main(image_handle: EfiHandle, efi_system_table: &EfiSystemTable) {
-    let mut vram = init_vram(efi_system_table).expect("init vram failed");
+    let mut sw = SerialPort::new_for_com1();
+    writeln!(sw, "Hello via serial port").unwrap();
 
+    let mut vram = init_vram(efi_system_table).expect("init vram failed");
     let vw = vram.width();
     let vh = vram.height();
     fill_rect(&mut vram, 0x000000, 0, 0, vw, vh).expect("fill black back failed");
     draw_test_pattern(&mut vram);
-
     let mut w = VramTextWriter::new(&mut vram);
     for i in 0..4 {
         writeln!(w, "i = {i}").unwrap();
     }
 
-    let mut memory_map = MemoryMapHolder::new();
-    let status = efi_system_table
-        .boot_services()
-        .get_memory_map(&mut memory_map);
-    writeln!(w, "{status:?}").unwrap();
-
+    let memory_map = init_basic_runtime(image_handle, efi_system_table);
     let mut total_memory_pages = 0;
     for e in memory_map.iter() {
         if e.memory_type() != EfiMemoryType::CONVENTIONAL_MEMORY {
@@ -54,9 +50,7 @@ fn efi_main(image_handle: EfiHandle, efi_system_table: &EfiSystemTable) {
     )
     .unwrap();
 
-    exit_from_efi_boot_services(image_handle, efi_system_table, &mut memory_map);
     writeln!(w, "Hello, Non-UEFI world!").unwrap();
-
     loop {
         hlt()
     }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,0 +1,56 @@
+use crate::x86::{busy_loop_hint, read_io_port_u8, write_io_port_u8};
+use core::fmt;
+
+pub struct SerialPort {
+    base: u16,
+}
+
+impl SerialPort {
+    pub fn new(base: u16) -> Self {
+        Self { base }
+    }
+    pub fn new_for_com1() -> Self {
+        // Use com1 at I/O port
+        Self::new(0x3f8)
+    }
+    pub fn init(&mut self) {
+        write_io_port_u8(self.base + 1, 0x00); // Disable all interrupts
+        write_io_port_u8(self.base + 3, 0x80); // Enable DLAB, set baud rate divisor
+
+        // baud rate = 115200 / BAUD_DIVISOR
+        const BAUD_DIVISOR: u16 = 0x0001;
+        write_io_port_u8(self.base, (BAUD_DIVISOR & 0xff) as u8);
+        write_io_port_u8(self.base + 1, (BAUD_DIVISOR >> 8) as u8);
+
+        write_io_port_u8(self.base + 3, 0x03); // 8 bits, no parity, one stop bit
+        write_io_port_u8(self.base + 2, 0xc7); // Enable FIFO, clear them, with 14 byte threshould
+        write_io_port_u8(self.base + 4, 0x0b); // IRQs enabled, RTS/DSR set
+    }
+    pub fn send_char(&self, c: char) {
+        while (read_io_port_u8(self.base + 5) & 0x20) == 0 {
+            busy_loop_hint();
+        }
+        write_io_port_u8(self.base, c as u8);
+    }
+    pub fn send_str(&self, s: &str) {
+        let mut sc = s.chars();
+        let slen = s.chars().count();
+        for _ in 0..slen {
+            self.send_char(sc.next().unwrap());
+        }
+    }
+}
+
+impl Default for SerialPort {
+    fn default() -> Self {
+        Self::new_for_com1()
+    }
+}
+
+impl fmt::Write for SerialPort {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let serial = Self::default();
+        serial.send_str(s);
+        Ok(())
+    }
+}

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -1,12 +1,37 @@
 use crate::qemu::exit_qemu;
 use crate::qemu::QemuExitCode;
+use crate::serial::SerialPort;
+use core::any::type_name;
+use core::fmt::Write;
 use core::panic::PanicInfo;
 
-pub fn test_runner(_tests: &[&dyn FnOnce()]) -> ! {
+pub trait Testable {
+    fn run(&self, writer: &mut SerialPort);
+}
+impl<T> Testable for T
+where
+    T: Fn(),
+{
+    fn run(&self, writer: &mut SerialPort) {
+        writeln!(writer, "[RUNNING] >>> {}", type_name::<T>()).unwrap();
+        self();
+        writeln!(writer, "[PASS   ] <<< {}", type_name::<T>()).unwrap();
+    }
+}
+
+pub fn test_runner(tests: &[&dyn Testable]) -> ! {
+    let mut sw = SerialPort::new_for_com1();
+    writeln!(sw, "Running {} tests...", tests.len()).unwrap();
+    for test in tests {
+        test.run(&mut sw);
+    }
+    writeln!(sw, "Completed {} tests!", tests.len()).unwrap();
     exit_qemu(QemuExitCode::Success)
 }
 
 #[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
+fn panic(info: &PanicInfo) -> ! {
+    let mut sw = SerialPort::new_for_com1();
+    writeln!(sw, "PANIC during test: {info:?}").unwrap();
     exit_qemu(QemuExitCode::Fail)
 }

--- a/src/uefi.rs
+++ b/src/uefi.rs
@@ -68,6 +68,9 @@ impl EfiMemoryDescriptor {
     pub fn number_of_pages(&self) -> u64 {
         self.number_of_pages
     }
+    pub fn physical_start(&self) -> u64 {
+        self.physical_start
+    }
 }
 
 #[repr(i64)]

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -12,3 +12,18 @@ pub fn write_io_port_u8(port: u16, data: u8) {
         )
     }
 }
+
+pub fn busy_loop_hint() {
+    unsafe { asm!("pause") }
+}
+
+pub fn read_io_port_u8(port: u16) -> u8 {
+    let mut data: u8;
+    unsafe {
+        asm!("in al, dx",
+            out("al") data,
+            in("dx") port,
+        )
+    }
+    data
+}


### PR DESCRIPTION
```
$ cargo test
   Compiling wasabi v0.1.0 (/Users/ca/go/src/github.com/ryo-yamaoka/wasabios)
    Finished test [unoptimized + debuginfo] target(s) in 0.21s
     Running unittests src/lib.rs (target/x86_64-unknown-uefi/debug/deps/wasabi-380ec770b839785e.efi)
cargo build --target x86_64-unknown-uefi
   Compiling wasabi v0.1.0 (/Users/ca/go/src/github.com/ryo-yamaoka/wasabios)
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
mkdir -p mnt/EFI/BOOT
cp /Users/ca/go/src/github.com/ryo-yamaoka/wasabios/target/x86_64-unknown-uefi/debug/deps/wasabi-380ec770b839785e.efi mnt/EFI/BOOT/BOOTX64.EFI
set +e; \
	qemu-system-x86_64 \
		-m 4G \
		-bios third_party/ovmf/RELEASEX64_OVMF.fd \
		-drive format=raw,file=fat:rw:mnt \
		-chardev stdio,id=char_com1,mux=on,logfile=log/com1.txt \
		-serial chardev:char_com1 \
		-device isa-debug-exit,iobase=0xf4,iosize=0x01; \
	EXIT_CODE=$?; \
	set -e; \
	if [ $EXIT_CODE -eq 0 ]; then \
		exit 0; \
	elif [ $EXIT_CODE -eq 3 ]; then \
		printf "\nPASS\n"; \
		exit 0; \
	else \
		printf "\nFAIL: QEMU returned $EXIT_CODE\n"; \
		exit 1; \
	fi
BdsDxe: failed to load Boot0001 "UEFI QEMU DVD-ROM QM00003 " from PciRoot(0x0)/Pci(0x1,0x1)/Ata(Secondary,Master,0x0): Not Found
BdsDxe: loading Boot0002 "UEFI QEMU HARDDISK QM00001 " from PciRoot(0x0)/Pci(0x1,0x1)/Ata(Primary,Master,0x0)
BdsDxe: starting Boot0002 "UEFI QEMU HARDDISK QM00001 " from PciRoot(0x0)/Pci(0x1,0x1)/Ata(Primary,Master,0x0)
Running 5 tests...
[RUNNING] >>> wasabi::allocator::round_up_to_nearest_pow2_test
[PASS   ] <<< wasabi::allocator::round_up_to_nearest_pow2_test
[RUNNING] >>> wasabi::allocator::test::allocated_objects_have_no_overlap
[PASS   ] <<< wasabi::allocator::test::allocated_objects_have_no_overlap
[RUNNING] >>> wasabi::allocator::test::malloc_align
[PASS   ] <<< wasabi::allocator::test::malloc_align
[RUNNING] >>> wasabi::allocator::test::malloc_align_random_order
[PASS   ] <<< wasabi::allocator::test::malloc_align_random_order
[RUNNING] >>> wasabi::allocator::test::malloc_iterate_free_and_alloc
[PASS   ] <<< wasabi::allocator::test::malloc_iterate_free_and_alloc
Completed 5 tests!

PASS
```